### PR TITLE
Add ModuleNameRegistration for dependency injection setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Full implementation spec is in `COPILOT_PROMPT.md`.
 - [x] **Phase 1** — `template.json` + token substitution verification
 - [x] **Phase 2** — Shared: `ModuleName.cs`, `IModuleNameService.cs`
 - [x] **Phase 3** — Server: `ModuleNameRepository.cs`, `ModuleNameManager.cs`, `ModuleNameController.cs`
-- [ ] **Phase 4** — Server: `ModuleNameRegistration.cs`
+- [x] **Phase 4** — Server: `ModuleNameRegistration.cs`
 - [ ] **Phase 5** — Client: `Index.razor`, `Edit.razor`, `Add.razor`, `Detail.razor`
 - [ ] **Phase 6** — NuGet packaging (`MarkDav.Oqtane.Module.Template.csproj`)
 - [ ] **Phase 7** — End-to-end test: scaffold into real Oqtane.Application solution, confirm build

--- a/templates/oqtane-module/Server/Registration/ModuleNameRegistration.cs
+++ b/templates/oqtane-module/Server/Registration/ModuleNameRegistration.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Oqtane.Infrastructure;
+using RootNamespace.Managers;
+using RootNamespace.Repository;
+using RootNamespace.Services;
+
+namespace RootNamespace
+{
+    public class ModuleNameRegistration : IServerStartup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddTransient<IModuleNameService, ModuleNameManager>();
+            services.AddTransient<IModuleNameRepository, ModuleNameRepository>();
+        }
+
+        public void Configure(IApplicationBuilder app, IServiceProvider serviceProvider) { }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the dependency injection registration class for the Oqtane module template, completing Phase 4 of the template implementation.

## Key Changes
- Added `ModuleNameRegistration.cs` implementing `IServerStartup` interface
- Registers `IModuleNameService` → `ModuleNameManager` as transient dependency
- Registers `IModuleNameRepository` → `ModuleNameRepository` as transient dependency
- Updated CLAUDE.md to mark Phase 4 as complete

## Implementation Details
The `ModuleNameRegistration` class follows the Oqtane framework's startup pattern by implementing `IServerStartup`. It configures the dependency injection container during application startup, enabling the service and repository layers to be properly injected throughout the module. The `Configure` method is left empty as no middleware configuration is required for this module.

https://claude.ai/code/session_017qNLVMRtzzYWT3MoZmTVjC